### PR TITLE
remove hgroup

### DIFF
--- a/basicss/base/_baseline.scss
+++ b/basicss/base/_baseline.scss
@@ -16,7 +16,7 @@ hr {
   padding: 0;
 }
 
-h1, h2, h3, h4, h5, h6, hgroup,
+h1, h2, h3, h4, h5, h6,
 ul, ol, dl,
 blockquote, p, address,
 table,


### PR DESCRIPTION
because it has been removed from the HTML5 specification, see: http://lists.w3.org/Archives/Public/public-html-admin/2013Apr/0003.html
