### PR TITLE
let spacing classes trump other styles

### DIFF
--- a/basicss/helper/_spacing.scss
+++ b/basicss/helper/_spacing.scss
@@ -4,26 +4,26 @@
 
   .space#{$scope}--top#{$name},
   %space#{$scope}--top#{$name} { 
-    margin-top: $baseUnit * $multiplier;
-    margin-top: toRem($baseUnit * $multiplier);
+    margin-top: $baseUnit * $multiplier !important;
+    margin-top: toRem($baseUnit * $multiplier) !important;
   }
 
   .space#{$scope}--left#{$name},
   %space#{$scope}--left#{$name} { 
-    margin-left: $baseUnit * $multiplier; 
-    margin-left: toRem($baseUnit * $multiplier);
+    margin-left: $baseUnit * $multiplier !important; 
+    margin-left: toRem($baseUnit * $multiplier) !important;
   }
 
   .space#{$scope}--right#{$name},
   %space#{$scope}--right#{$name} { 
-    margin-right: $baseUnit * $multiplier; 
-    margin-right: toRem($baseUnit * $multiplier);
+    margin-right: $baseUnit * $multiplier !important; 
+    margin-right: toRem($baseUnit * $multiplier) !important;
   }
 
   .space#{$scope}--bottom#{$name},
   %space#{$scope}--bottom#{$name} { 
-    margin-bottom: $baseUnit * $multiplier; 
-    margin-bottom: toRem($baseUnit * $multiplier);
+    margin-bottom: $baseUnit * $multiplier !important; 
+    margin-bottom: toRem($baseUnit * $multiplier) !important;
   }
 }
 


### PR DESCRIPTION
Make sure that the classes defined in `_spacing.scss` always trump other margins attached to an element we want to use them on.

See:
[https://github.com/inuitcss/trumps.spacing](https://github.com/inuitcss/trumps.spacing)
